### PR TITLE
Update annotations for requests.api.get

### DIFF
--- a/third_party/2/requests/api.pyi
+++ b/third_party/2/requests/api.pyi
@@ -1,15 +1,20 @@
-# Stubs for requests.api (Python 3)
+# Stubs for requests.api (Python 2)
 
-from typing import Union, Optional, AnyStr
+from typing import Union, Optional, Iterable, Dict
 
 from .models import Response
 
 def request(method: str, url: str, **kwargs) -> Response: ...
 
 def get(url: Union[str, unicode],
-        params: Optional[Union[dict[Union[str, unicode],
-                                    Union[str, unicode]],
-                               Union[str, unicode]]]=None,
+        params: Optional[
+               Union[
+                Dict[Union[str, unicode, int, float],
+                     Union[str, unicode, int, float, Iterable]], 
+                Union[str, unicode], 
+                Tuple[Union[str, unicode, int, float], 
+                      Union[str, unicode, int, float, Iterable]]
+               ]]=None,
         **kwargs) -> Response: ...
 
 def options(url: Union[str, unicode], **kwargs) -> Response: ...


### PR DESCRIPTION
Argument 'params' of requests.api.get accepts not only dictionaries of str, str pairs, but dictionaries and tuples containing various types.

Details in this issue: https://github.com/python/typeshed/issues/840